### PR TITLE
View/ScoreboardPage

### DIFF
--- a/lib/app/bindings/main_binding.dart
+++ b/lib/app/bindings/main_binding.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:new_fit/app/bindings/scoreboard_page_binding.dart';
 import 'package:new_fit/app/controller/main/main_controller.dart';
 
 class MainBinding implements Bindings {
@@ -7,5 +8,6 @@ class MainBinding implements Bindings {
     Get.lazyPut<MainController>(() {
       return MainController();
     });
+    ScoreboardPageBinding().dependencies();
   }
 }

--- a/lib/app/bindings/scoreboard_page_binding.dart
+++ b/lib/app/bindings/scoreboard_page_binding.dart
@@ -1,0 +1,11 @@
+import 'package:get/get.dart';
+import 'package:new_fit/app/controller/score_page_controller.dart';
+
+class ScoreboardPageBinding implements Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<ScoreboardPageController>(() {
+      return ScoreboardPageController();
+    });
+  }
+}

--- a/lib/app/controller/score_page_controller.dart
+++ b/lib/app/controller/score_page_controller.dart
@@ -1,0 +1,3 @@
+import 'package:new_fit/app/core/base/base_controller.dart';
+
+class ScoreboardPageController extends BaseController {}

--- a/lib/app/data/model/enum/menu_code.dart
+++ b/lib/app/data/model/enum/menu_code.dart
@@ -1,3 +1,3 @@
 // ignore_for_file: constant_identifier_names
 
-enum MenuCode { HOME, RESERVE, QR, MYPAGE }
+enum MenuCode { HOME, RESERVE, QR, SCOREBOARD }

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -4,10 +4,12 @@ import 'package:get/get.dart';
 import 'package:new_fit/app/bindings/my_page_binding.dart';
 import 'package:new_fit/app/bindings/register_binding.dart';
 import 'package:new_fit/app/bindings/login_binding.dart';
+import 'package:new_fit/app/bindings/scoreboard_page_binding.dart';
 import 'package:new_fit/app/view/login_page/login_page.dart';
 import 'package:new_fit/app/view/main_page.dart';
 import 'package:new_fit/app/view/my_page/my_page.dart';
 import 'package:new_fit/app/view/register_page/register_page.dart';
+import 'package:new_fit/app/view/scoreboard_page/scoreboard_page.dart';
 
 import '../bindings/main_binding.dart';
 
@@ -21,6 +23,7 @@ class AppPages {
   static const REGISTER = Routes.REGISTER;
   static const LOGIN = Routes.LOGIN;
   static const MY = Routes.MY;
+  static const SCOREBOARD = Routes.SCOREBOARD;
   static const TEST_PAGE = Routes.TEST_PAGE;
 
   static final pages = [
@@ -45,6 +48,12 @@ class AppPages {
       name: _Paths.MY,
       page: () => MyPage(),
       binding: MyPageBinding(),
+      transition: Transition.fadeIn,
+    ),
+    GetPage(
+      name: _Paths.SCOREBOARD,
+      page: () => ScoreboardPage(),
+      binding: ScoreboardPageBinding(),
       transition: Transition.fadeIn,
     ),
   ];

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -12,6 +12,7 @@ abstract class Routes {
   static const MAIN = _Paths.MAIN;
   static const SETTING = _Paths.SETTING;
   static const MY = _Paths.MY;
+  static const SCOREBOARD = _Paths.SCOREBOARD;
 }
 
 abstract class _Paths {
@@ -21,4 +22,5 @@ abstract class _Paths {
   static const MAIN = "/main";
   static const SETTING = "/setting";
   static const MY = "/my";
+  static const SCOREBOARD = '/scoreboard';
 }

--- a/lib/app/view/common/newfit_appbar.dart
+++ b/lib/app/view/common/newfit_appbar.dart
@@ -18,12 +18,86 @@ class NewfitAppBar extends StatelessWidget implements PreferredSizeWidget {
   MainController mainController;
   ScrollController scrollController;
   Rx<double> scrollPosition = 0.0.obs;
+  double appBarHeight = 183.h;
 
   @override
   Widget build(BuildContext context) {
-    return Obx(() {
-      return Container();
-    });
+    Widget replaceWidget = homeAppBar();
+    scrollController.addListener(_scrollListener);
+
+    return Obx(
+      () {
+        if (mainController.selectedMenuCode == MenuCode.HOME) {
+          replaceWidget = homeAppBar();
+          if (scrollPosition.value > 0.0) {
+            appBarHeight = 105.h + MediaQuery.of(context).padding.top;
+          } else {
+            appBarHeight = 175.h + MediaQuery.of(context).padding.top;
+          }
+        } else if (mainController.selectedMenuCode == MenuCode.SCOREBOARD) {
+          replaceWidget = SafeArea(
+            child: Center(
+              child: NewfitTextBoldXl(
+                text: "스코어보드",
+                textColor: AppColors.black,
+              ),
+            ),
+          );
+          appBarHeight = 50.h + MediaQuery.of(context).padding.top;
+        }
+        return Container(
+          height: appBarHeight,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.only(
+              bottomLeft: Radius.circular(16.r),
+              bottomRight: Radius.circular(16.r),
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.2),
+                spreadRadius: 0,
+                blurRadius: 25.r,
+                offset: const Offset(0, 0),
+              ),
+            ],
+            color: Colors.white,
+          ),
+          child: SafeArea(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(20.w, 0, 20.w, 0),
+              child: replaceWidget,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget homeAppBar() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(height: 13.h),
+        _UserInfoAppBar(
+          userName: "고라니",
+          onPressedFucntion: () {},
+        ),
+        if (scrollPosition.value <= 0.0) SizedBox(height: 13.h),
+        if (scrollPosition.value <= 0.0)
+          _UserCreditInfo(
+            totalCredit: 10000,
+            todayCredit: 100,
+          ),
+        SizedBox(height: 15.h),
+        Align(
+          alignment: Alignment.center,
+          child: NewfitButton(
+              buttonText: "루틴으로 예약하기",
+              buttonColor: AppColors.main,
+              onPressFuntion: () {}),
+        ),
+      ],
+    );
   }
 
   _scrollListener() {
@@ -56,16 +130,14 @@ class NewfitAppBarWithButton extends StatelessWidget
   Widget build(BuildContext context) {
     scrollController.addListener(_scrollListener);
 
-    return Obx(() {
-      if (scrollPosition.value > 0.0) {
-        appBarHeight = 105.h + MediaQuery.of(context).padding.top;
-        creditInfo = const SizedBox();
-      } else {
-        appBarHeight = 175.h + MediaQuery.of(context).padding.top;
-        creditInfo =
-            _UserCreditInfo(totalCredit: totalCredit, todayCredit: todayCredit);
-      }
-      return Container(
+    return Obx(
+      () {
+        if (scrollPosition.value > 0.0) {
+          appBarHeight = 105.h + MediaQuery.of(context).padding.top;
+        } else {
+          appBarHeight = 175.h + MediaQuery.of(context).padding.top;
+        }
+        return Container(
           height: appBarHeight,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.only(
@@ -106,12 +178,14 @@ class NewfitAppBarWithButton extends StatelessWidget
                         buttonText: "루틴으로 예약하기",
                         buttonColor: AppColors.main,
                         onPressFuntion: () {}),
-                  )
+                  ),
                 ],
               ),
             ),
-          ));
-    });
+          ),
+        );
+      },
+    );
   }
 
   _scrollListener() {
@@ -355,6 +429,15 @@ class NewfitAppBarTranparent extends StatelessWidget
 
   _scrollListener() {
     scrollPosition.value = scrollController.offset;
+  }
+}
+
+class _HomeAppBar extends StatelessWidget {
+  const _HomeAppBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
   }
 }
 

--- a/lib/app/view/common/newfit_appbar.dart
+++ b/lib/app/view/common/newfit_appbar.dart
@@ -1,10 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:get/get.dart';
+import 'package:new_fit/app/controller/main/main_controller.dart';
+import 'package:new_fit/app/data/model/enum/menu_code.dart';
 import 'package:new_fit/app/view/common/newfit_button.dart';
 import 'package:new_fit/app/view/common/newfit_progressbar.dart';
 import 'package:new_fit/app/view/theme/app_colors.dart';
 import 'package:new_fit/app/view/theme/app_text_theme.dart';
+
+class NewfitAppBar extends StatelessWidget implements PreferredSizeWidget {
+  NewfitAppBar({
+    required this.mainController,
+    required this.scrollController,
+    super.key,
+  });
+
+  MainController mainController;
+  ScrollController scrollController;
+  Rx<double> scrollPosition = 0.0.obs;
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      return Container();
+    });
+  }
+
+  _scrollListener() {
+    scrollPosition.value = scrollController.offset;
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(appBarHeight);
+}
 
 class NewfitAppBarWithButton extends StatelessWidget
     implements PreferredSizeWidget {
@@ -96,7 +124,7 @@ class NewfitAppBarWithButton extends StatelessWidget
 
 class NewfitAppBarElevated extends StatelessWidget
     implements PreferredSizeWidget {
-  const NewfitAppBarElevated({
+  NewfitAppBarElevated({
     super.key,
     required this.appBarTitleText,
   });

--- a/lib/app/view/common/newfit_bottom_nav_bar.dart
+++ b/lib/app/view/common/newfit_bottom_nav_bar.dart
@@ -74,7 +74,7 @@ class NewfitBottomNavigationBar extends StatelessWidget {
       ),
       const BottomNavItem(
         iconSVGName: AppString.mypage,
-        menuCode: MenuCode.MYPAGE,
+        menuCode: MenuCode.SCOREBOARD,
       ),
     ];
   }

--- a/lib/app/view/common/newfit_circle_avatar.dart
+++ b/lib/app/view/common/newfit_circle_avatar.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class NewfitCircleAvatar extends StatelessWidget {
+  const NewfitCircleAvatar({
+    required this.radius,
+    super.key,
+  });
+
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleAvatar(
+      radius: 20.h,
+    );
+  }
+}

--- a/lib/app/view/common/newfit_circle_avatar.dart
+++ b/lib/app/view/common/newfit_circle_avatar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:new_fit/app/view/theme/app_colors.dart';
+import 'package:new_fit/app/view/theme/app_text_theme.dart';
 
 class NewfitCircleAvatar extends StatelessWidget {
   const NewfitCircleAvatar({
@@ -11,8 +13,24 @@ class NewfitCircleAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CircleAvatar(
-      radius: 20.h,
+    return SizedBox(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          CircleAvatar(
+            radius: radius,
+          ),
+          SizedBox(height: 15.h),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.circle),
+              SizedBox(width: 5.w),
+              NewfitTextBoldXl(text: 'gorani', textColor: AppColors.black),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/app/view/common/newfit_lists.dart
+++ b/lib/app/view/common/newfit_lists.dart
@@ -86,12 +86,16 @@ class NewfitScoreboardListCell extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       child: Container(
-        width: double.infinity,
+        width: 320.w,
         height: 56.h,
+        decoration: BoxDecoration(
+          color: AppColors.white,
+          borderRadius: BorderRadius.circular(8.h),
+        ),
         child: Row(
           children: [
             Padding(
-                padding: EdgeInsets.fromLTRB(30.w, 0, 25.w, 0),
+                padding: EdgeInsets.fromLTRB(20.w, 0, 25.w, 0),
                 child: NewfitTextMediumMd(
                     text: "$rank", textColor: AppColors.black)),
             CircleAvatar(), // NewfitCircleAvatar 로 변경될 예정
@@ -102,7 +106,7 @@ class NewfitScoreboardListCell extends StatelessWidget {
             ),
             const Spacer(),
             Padding(
-              padding: EdgeInsets.fromLTRB(0, 0, 40.w, 0),
+              padding: EdgeInsets.fromLTRB(0, 0, 20.w, 0),
               child: NewfitTextRegularMd(
                   text: "$credit credit", textColor: AppColors.textUnabled),
             ),

--- a/lib/app/view/main_page.dart
+++ b/lib/app/view/main_page.dart
@@ -8,6 +8,7 @@ import 'package:new_fit/app/data/model/enum/menu_code.dart';
 import 'package:new_fit/app/view/common/newfit_bottom_nav_bar.dart';
 import 'package:new_fit/app/view/common/newfit_text_field.dart';
 import 'package:new_fit/app/view/main/home_page.dart';
+import 'package:new_fit/app/view/scoreboard_page/scoreboard_page.dart';
 import 'package:new_fit/app/view/theme/app_colors.dart';
 import 'package:new_fit/app/view/theme/app_text_theme.dart';
 
@@ -17,10 +18,9 @@ class MainPage extends BaseView<MainController> {
   ScrollController scrollController = ScrollController(initialScrollOffset: 0);
   @override
   PreferredSizeWidget? appBar(BuildContext context) {
-    return NewfitAppBarWithButton(
+    return NewfitAppBar(
+      mainController: controller,
       scrollController: scrollController,
-      todayCredit: 10000,
-      totalCredit: 10000,
     );
   }
 
@@ -28,7 +28,9 @@ class MainPage extends BaseView<MainController> {
   Widget body(BuildContext context) {
     return Container(
       key: UniqueKey(),
-      child: Obx(() => getPageOnSelectedMenu(controller.selectedMenuCode)),
+      child: Obx(() {
+        return getPageOnSelectedMenu(controller.selectedMenuCode);
+      }),
     );
   }
 
@@ -53,40 +55,12 @@ class MainPage extends BaseView<MainController> {
           height: 100,
           width: 100,
         );
-      case MenuCode.MYPAGE:
-        // return goalView;
-        return Container();
+      case MenuCode.SCOREBOARD:
+        return ScoreboardPage();
+
       default:
         // return LoginPage();
         return Container();
     }
-  }
-}
-
-class _BasePage extends StatelessWidget {
-  final List<Widget> widgetList;
-  ScrollController scrollController;
-  _BasePage({
-    required this.widgetList,
-    required this.scrollController,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-      child: Container(
-        padding:
-            const EdgeInsets.symmetric(horizontal: AppValues.screenPadding),
-        width: double.infinity,
-        child: SingleChildScrollView(
-          controller: scrollController,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: widgetList,
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/app/view/scoreboard_page/scoreboard_page.dart
+++ b/lib/app/view/scoreboard_page/scoreboard_page.dart
@@ -1,25 +1,71 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter/src/widgets/preferred_size.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:new_fit/app/controller/score_page_controller.dart';
 import 'package:new_fit/app/core/base/base_view.dart';
 import 'package:new_fit/app/view/common/base_body.dart';
 import 'package:new_fit/app/view/common/newfit_appbar.dart';
+import 'package:new_fit/app/view/common/newfit_circle_avatar.dart';
+import 'package:new_fit/app/view/common/newfit_lists.dart';
 
 class ScoreboardPage extends BaseView<ScoreboardPageController> {
   ScrollController scrollController = ScrollController(initialScrollOffset: 0);
 
   @override
   PreferredSizeWidget? appBar(BuildContext context) {
-    return NewfitAppBarTranparent(
-        scrollController: scrollController, appBarTitleText: '스코어보드');
+    return null;
   }
 
   @override
   Widget body(BuildContext context) {
     return BaseBody(
       scrollController: scrollController,
-      widgetList: [],
+      widgetList: scoreboardList(20),
     );
   }
+}
+
+List<Widget> scoreboardList(int length) {
+  return List.generate(length + 1, (index) {
+    if (index == 0) {
+      return Column(
+        children: [
+          SizedBox(
+            height: 20.h,
+          ),
+          Stack(
+            children: [
+              Positioned(
+                top: 80.h,
+                width: 320.w,
+                child: Row(
+                  children: [
+                    NewfitCircleAvatar(radius: 40.h),
+                    Spacer(),
+                    NewfitCircleAvatar(radius: 40.h),
+                  ],
+                ),
+              ),
+              NewfitCircleAvatar(radius: 50.h),
+              SizedBox(
+                width: 360.w,
+                height: 200.h,
+              )
+            ],
+          ),
+          SizedBox(height: 20.h),
+        ],
+      );
+    }
+    return Padding(
+      padding: EdgeInsets.only(bottom: 10.h),
+      child: NewfitScoreboardListCell(
+        rank: index,
+        userNickName: 'userNickName',
+        credit: 1000,
+        image: Image.asset('images/gorani.png'),
+      ),
+    );
+  });
 }

--- a/lib/app/view/scoreboard_page/scoreboard_page.dart
+++ b/lib/app/view/scoreboard_page/scoreboard_page.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter/src/widgets/preferred_size.dart';
+import 'package:new_fit/app/controller/score_page_controller.dart';
+import 'package:new_fit/app/core/base/base_view.dart';
+import 'package:new_fit/app/view/common/base_body.dart';
+import 'package:new_fit/app/view/common/newfit_appbar.dart';
+
+class ScoreboardPage extends BaseView<ScoreboardPageController> {
+  ScrollController scrollController = ScrollController(initialScrollOffset: 0);
+
+  @override
+  PreferredSizeWidget? appBar(BuildContext context) {
+    return NewfitAppBarTranparent(
+        scrollController: scrollController, appBarTitleText: '스코어보드');
+  }
+
+  @override
+  Widget body(BuildContext context) {
+    return BaseBody(
+      scrollController: scrollController,
+      widgetList: [],
+    );
+  }
+}


### PR DESCRIPTION
## 개요
스코어보드 페이지를 구현했습니다.

## 추가정보
### ScoreboardeListCell 컴포넌트 수정
기존에 색상 없이 백그라운드 색상을 따라가게 되어있었는데, 위젯 잘림 이슈로 패딩이 들어가면서 경계를 넣기 위해 색상을 넣고 테두리 값도 넣었습니다.

### NewfitAppBar 컴포넌트 생성
이전에 언급했던 문제, body 부분처럼 obx()를 통해 유동적으로 앱바를 갈아끼울 수 없는 문제로 인하여 AppBar를 하나로 합쳤습니다.
이제 메뉴코드를 통해 다른 모습의 AppBar를 보여주게 됩니다.
현재는 MenuCode.HOME 과 MenuCode.SCOREBOARD 만 설정이 되어있습니다. 이후 다른 뷰를 만들게 되면 추가적으로 앱바에도 업데이트가 있을 것입니다.

### NewfitCircleAvatar 컴포넌트 생성
스코어보드에 1, 2, 3등 유저의 사진을 보여줘야 하여 이에 맞게 새로운 컴포넌트를 생성했습니다.

## 문제점
새롭게 만든 컴포넌트들과 기존에 있는 컴포넌트들 모두 더미 데이터가 들어간 뼈대 위젯들이기에 컨트롤러 연결과 함께 매개변수 수정이 필요합니다.